### PR TITLE
Malformed XML in React/latest ui.content

### DIFF
--- a/ui.content/src/main/content/jcr_root/conf/wknd-spa-react/settings/wcm/template-types/spa-page/initial/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd-spa-react/settings/wcm/template-types/spa-page/initial/.content.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">


### PR DESCRIPTION
Fixes #25

Removes the linefeed that breaks XML compilance

## Motivation and Context

It isn't possible to install the `ui.content` artifact built from `React/latest` branch on AEM.
Since this is an ~year old change ([from Aug '20](https://github.com/adobe/aem-guides-wknd-spa/commit/979abb88156ed06b6b50115245328063e4723a47#diff-0f8c3b0000d0cd642dcd2cefb06d16a5014ff6756d48ee4032f4e210ef1e8741)), it is likely to exist in other branches as well, but I haven't gone down that path.

## How Has This Been Tested?

* built the `ui.content` and the dependencies from the latest state of the branch; installation of artifact failed on AEM
* applied the patch, rebuilt the content-package; installation of artifact on AEM succeeded.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- ~[ ] My change requires a change to the documentation.~
- ~[ ] I have updated the documentation accordingly.~
- [x] I have read the **CONTRIBUTING** document.
- ~[ ] I have added tests to cover my changes.~
- [x] All new and existing tests passed.
